### PR TITLE
Bugfix in StopCondition

### DIFF
--- a/src/mlx_textgen/utils.py
+++ b/src/mlx_textgen/utils.py
@@ -136,7 +136,7 @@ def stopping_criteria(
         StopCondition: A status class stating whether the generation should stop and the length of text to trim.
     """
     if eos_tuple is not None and eos_tuple[0] in text:
-        return StopCondition(stop_met=True, trim_length=len(text.split(eos_tuple)[-1]) + eos_tuple[1])
+        return StopCondition(stop_met=True, trim_length=len(text.split(eos_tuple[0])[-1]) + eos_tuple[1])
 
     return next(
         (StopCondition(stop_met=True, trim_length=length + len(text.split(stop)[-1]))


### PR DESCRIPTION
…/python3.12/site-packages/mlx_textgen/utils.py", line 139, in stopping_criteria

return StopCondition(stop_met=True, trim_length=len(text.split(eos_tuple)[-1]) + eos_tuple[1]) | TypeError: must be str or None, not list

TODO: When streaming Qwen, the stream still ends with "<|im" -> check with other models if their eos is correctly trimmed or not.