### PR TITLE
feat: add `hosts` arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,19 @@
 [![PyPI - License](https://img.shields.io/pypi/l/mlx-textgen)](https://pypi.org/project/mlx-textgen/)
 [![GitHub Repo stars](https://img.shields.io/github/stars/nath1295/mlx-textgen)](https://pypi.org/project/mlx-textgen/)
 
-## A python package for serving LLM on OpenAI-compatible API endpoints with prompt caching using MLX  
+## A OpenAI-compatible API LLM engine with smart prompt caching, batch processing, structured output with guided decoding, and function calling for all models using MLX  
 
 MLX-Textgen is a light-weight LLM serving engine that utilize MLX and a smart KV cache management system to make your LLM generation more seamless on your Apple silicon machine. It features:
-- Multiple KV-cache slots to reduce the needs of prompt processing
-- Multiple models serving with Fastapi
-- Common OpenAI API endpoints: `/v1/models`, `/v1/completions`, `/v1/chat/completions`
+- **Multiple KV-cache slots to reduce the needs of prompt processing**
+- **Structured text generation with json schemas, regex, or context free grammar**
+- **Batch inferencing with multiple prompts**
+- **Multiple models serving with Fastapi**
+- **Common OpenAI API endpoints: `/v1/models`, `/v1/completions`, `/v1/chat/completions`**
+
+It is built with:
+1. [mlx-lm](https://github.com/ml-explore/mlx-examples)
+2. [Outlines](https://github.com/dottxt-ai/outlines)
+3. [FastAPI](https://github.com/fastapi/fastapi)
 
 ## Updates
 **2024-10-20** - Batch inference and function calling supported. Breaking changes in the save format for the KV caches. Run `mlx_textgen.clear_cache` after updating to avoid issues.
@@ -20,9 +27,56 @@ MLX-textgen can be easily installed with `pip`:
 pip install mlx-textgen
 ```
 
+## Usage
+### 1. Serving a single model
+You can quickly set up a OpenAI API server with a single command.
+
+```bash
+mlx_textgen.server --model NousResearch/Hermes-3-Llama-3.1-8B --quantize q8 --port 5001 --host 127.0.0.1
+```
+
+### 2. Serving a multiple models server
+Create a config file template and add as many model as you like.
+```bash
+mlx_textgen.create_config --num-models 2
+```
+
+It will generate a file called `model_config.yaml`. Edit this file for the models you want to serve.
+```yaml
+- model_id_or_path: NousResearch/Hermes-3-Llama-3.1-8B
+  tokenizer_id_or_path: null
+  adapter_path: null
+  quant: q8
+  revision: null
+  model_name: null
+  model_config: null
+  tokenizer_config: null
+- model_id_or_path: mlx-community/Llama-3.2-3B-Instruct-4bit
+  tokenizer_id_or_path: null
+  adapter_path: null
+  quant: q4
+  revision: null
+  model_name: llama-3.2-3b-instruct
+  model_config: null
+  tokenizer_config: null
+```
+
+Then start the engine:
+```bash
+mlx_textgen.server --config-file ./model_config.yaml --port 5001 --host 127.0.0.1
+```
+
+### 3. More engine arguments
+You can check the details of other engine arguments by running:
+```bash
+mlx_textgen.server --help
+```
+
+You can specify the number of cache slots for each model, minimum number of tokens to create a cache file, and API keys etc.
+
 ## Features
 ### 1. Multiple KV cache slots support
-All the KV cache are stored on disk. Therefore, unlike other LLM serving engine, a newly created KV cache will not overwrite the existing KV cache. This works better for agenic workflows where different types of prompts are being used frequently without losing previous cache for a long prompt.
+All the KV cache are stored on disk. Therefore, unlike other LLM serving engine, a newly created KV cache will not overwrite the existing KV cache. This works better for agentic workflows where different types of prompts are being used frequently without losing previous cache for a long prompt.
 
 ### 2. Guided decoding with Regex, Json schema, and Grammar
 You can pass your guided decoding argument `guided_json`, `guided_choice`, `guided_regex`, or `guided_grammar` as extra arguments and create structured text generation in a similar fashion to [vllm](https://github.com/vllm-project/vllm).
@@ -123,53 +177,6 @@ for i in client.chat.completions.create(
 
 # Output: {"first_name": "David", "last_name": "Stone", "age": 35}
 ```
-
-## Usage
-### 1. Serving a single model
-You can quickly set up a OpenAI API server with a single command.
-
-```bash
-mlx_textgen.server --model NousResearch/Hermes-3-Llama-3.1-8B --qunatize q8 --port 5001
-```
-
-### 2. Serving a multiple models server
-Create a config file template and add as many model as you like.
-```bash
-mlx_textgen.create_config --num-models 2
-```
-
-It will generate a file called `model_config.yaml`. Edit this file for the models you want to serve.
-```yaml
-- model_id_or_path: NousResearch/Hermes-3-Llama-3.1-8B
-  tokenizer_id_or_path: null
-  adapter_path: null
-  quant: q8
-  revision: null
-  model_name: null
-  model_config: null
-  tokenizer_config: null
-- model_id_or_path: mlx-community/Llama-3.2-3B-Instruct-4bit
-  tokenizer_id_or_path: null
-  adapter_path: null
-  quant: q4
-  revision: null
-  model_name: llama-3.2-3b-instruct
-  model_config: null
-  tokenizer_config: null
-```
-
-Then start the engine:
-```bash
-mlx_textgen.server --config-file ./model_config.yaml --port 5001
-```
-
-### 3. More engine arguments
-You can check the details of other engine arguments by running:
-```bash
-mlx_textgen.server --help
-```
-
-You can specify the number of cache slots for each model, minimum number of tokens to create a cache file, and API keys etc.
 
 ## License
 This project is licensed under the terms of the MIT license.


### PR DESCRIPTION
This PR allows the user to add a `--hosts` flag to specify an alternate host (e.g. 0.0.0.0 to expose server on a local network). It defaults to 127.0.0.1 so it is not a breaking change.